### PR TITLE
hotfix(backend): fix spotty backend compilation while testing

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -41,6 +41,10 @@ def test_database():
 def server(test_database):
     env = os.environ.copy()
     env["DATABASE_URL"] = f"sqlite:{test_database}"
+    
+    # Offline mode makes sqlx (the rust database bridge used) skip validation with live DB
+    # The backend works fine without it, but sqlx doesn't compile otherwise
+    env["OFFLINE_MODE"] = "true"
 
     proc = subprocess.Popen(
         ["cargo", "run"],


### PR DESCRIPTION
Bug spotted: backend would not compile when test.db file isn't present. This is a one-time compilation thing, that would not bother testing regularly, but would cause trouble when backend needed to be recompiled and there happened to not be a test database present.